### PR TITLE
PROGRAM_NAME deprecated

### DIFF
--- a/files/tutorial/files/read_file.p6
+++ b/files/tutorial/files/read_file.p6
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl6
 use v6;
 
-my $filename = $*PROGRAM_NAME;
+my $filename = $*PROGRAM-NAME;
 
 my $fh = open $filename;
 for $fh.lines -> $line {

--- a/files/tutorial/files/read_file_into_array.p6
+++ b/files/tutorial/files/read_file_into_array.p6
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl6
 use v6;
 
-my $filename = $*PROGRAM_NAME;
+my $filename = $*PROGRAM-NAME;
 
 # reads all the content of the file in the first element of the array!
 my @content = slurp $filename;

--- a/files/tutorial/files/read_file_line_by_line.p6
+++ b/files/tutorial/files/read_file_line_by_line.p6
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl6
 use v6;
 
-my $filename = $*PROGRAM_NAME;
+my $filename = $*PROGRAM-NAME;
 
 my $fh = open $filename;
 while (defined my $line = $fh.get) {

--- a/files/tutorial/files/read_one_line.p6
+++ b/files/tutorial/files/read_one_line.p6
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl6
 use v6;
 
-my $filename = $*PROGRAM_NAME;
+my $filename = $*PROGRAM-NAME;
 
 my $fh = open $filename;
 my $line = $fh.get;

--- a/files/tutorial/files/slurp_file.p6
+++ b/files/tutorial/files/slurp_file.p6
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl6
 use v6;
 
-my $filename = $*PROGRAM_NAME;
+my $filename = $*PROGRAM-NAME;
 
 my $data = slurp $filename;
 say $data.bytes;

--- a/pages/tutorial/perl6-read-from-file.txt
+++ b/pages/tutorial/perl6-read-from-file.txt
@@ -29,4 +29,3 @@ The specifications of all the IO of Perl 6 can be found in
 S32-setting-library/IO.pod
 
 <include file="tutorial/files/read_one_line.p6" />
-

--- a/pages/tutorial/perl6-twigils-and-special-variables.txt
+++ b/pages/tutorial/perl6-twigils-and-special-variables.txt
@@ -16,7 +16,7 @@ and the name of the variable.
 
 Examples:
 <ul>
- <li><emp>$*PROGRAM_NAME</emp> relative path to the currently running Perl 6 script.</li>
+ <li><emp>$*PROGRAM-NAME</emp> relative path to the currently running Perl 6 script.</li>
  <li><emp>$*PROGRAM</emp> full path to the currently running Perl 6 cript</li>
  <li><emp>$*CWD</emp> contains a path to the current working directory.</li>
  <li><emp>$*IN</emp> is the standard input (STDIN). You can read a line using $*IN.get</li>


### PR DESCRIPTION
First off, thanks for the awesome tutorials, They're very helpful to me as a novice programmer and I'm really enjoying them.  Using Perl6 v2015.06-85-goff4557 (MoarVM v2015.06-44-gc96984) I got the following warning:

```
Saw 1 occurrence of deprecated code.
================================================================================
$*PROGRAM_NAME seen at:
  /home/austin/git/scripts/demos/perl6/slurp.p6, line 4
Deprecated since v2015.6, will be removed with release v2015.9!
Please use $*PROGRAM-NAME instead.
--------------------------------------------------------------------------------
Please contact the author to have these occurrences of deprecated code
adapted, so that this message will disappear!

Please note that *ALL* deprecated features will be removed at the RC-0 release
(expected September 2015)
```