### PR TITLE
delete macros.p6

### DIFF
--- a/files/tutorial/other/macros.p6
+++ b/files/tutorial/other/macros.p6
@@ -1,9 +1,0 @@
-use v6;
-
-say "before";
-
-macro abc() {
-    say 42;
-}
-
-say "after";


### PR DESCRIPTION
it's not referenced in any document, it doesn't compile, and
it doesn't actually use the macro it defines at all.

alternatively you could "use experimental :macros" to make it compile.